### PR TITLE
trltespr: Fix RIL definition elements

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -2,3 +2,5 @@
 rild.libargs=-d /dev/smd0
 rild.libpath=/system/lib/libsec-ril.so
 ro.telephony.ril.config=newril
+ro.telephony.ril_class=trlteRIL
+ro.ril.telephony.mqanelements=6


### PR DESCRIPTION
Change-Id: I3c5e9c4afd4d7a145ae70827be1b60bb866c9fc7
