### PR TITLE
trltespr: Update RIL to resolve dialEmergency issue

### DIFF
--- a/ril/telephony/java/com/android/internal/telephony/trlteRIL.java
+++ b/ril/telephony/java/com/android/internal/telephony/trlteRIL.java
@@ -496,11 +496,13 @@ public class trlteRIL extends RIL implements CommandsInterface {
     dialEmergencyCall(String address, int clirMode, Message result) {
         RILRequest rr;
         Rlog.v(RILJ_LOG_TAG, "Emergency dial: " + address);
-
         rr = RILRequest.obtain(RIL_REQUEST_DIAL_EMERGENCY, result);
-        rr.mParcel.writeString(address + "/");
+        rr.mParcel.writeString(address);
         rr.mParcel.writeInt(clirMode);
-        rr.mParcel.writeInt(0);  // UUS information is absent
+        rr.mParcel.writeInt(0);        // CallDetails.call_type
+        rr.mParcel.writeInt(3);        // CallDetails.call_domain
+        rr.mParcel.writeString("");    // CallDetails.getCsvFromExtra
+        rr.mParcel.writeInt(0);        // Unknown
 
         if (RILJ_LOGD) riljLog(rr.serialString() + "> " + requestToString(rr.mRequest));
 


### PR DESCRIPTION
The phone would lock up after appending the / to the dial address.
This RIL was sourced from hlte, but trlte does not respond to the
/ in the dial address as hlte does, causing the phone to not dial.

Change-Id: Ia88b3dc415e6ac398aa2b76b738441e9aedd222a
